### PR TITLE
handle undefined data attrs

### DIFF
--- a/src/tippy.js
+++ b/src/tippy.js
@@ -11,7 +11,7 @@ const hasBindingChanged = (value, oldValue) => {
 export default (opts = {}) => {
   const init = (el, { value = {}, oldValue = {} }, vnode) => {
     if (!el.getAttribute('title')) {
-      const title = value.title || (vnode.data.attrs || {}).title || opts.title
+      const title = value.title || vnode.data.attrs && vnode.data.attrs.title || opts.title
       if (title) {
         el.setAttribute('title', title)
       }

--- a/src/tippy.js
+++ b/src/tippy.js
@@ -11,7 +11,7 @@ const hasBindingChanged = (value, oldValue) => {
 export default (opts = {}) => {
   const init = (el, { value = {}, oldValue = {} }, vnode) => {
     if (!el.getAttribute('title')) {
-      const title = value.title || vnode.data.attrs.title || opts.title
+      const title = value.title || (vnode.data.attrs || {}).title || opts.title
       if (title) {
         el.setAttribute('title', title)
       }


### PR DESCRIPTION
I found that when creating html tippies like `<div v-tippy="{ html: '#myTemplate' }">tippy</div>` there is no need to pass the `title` attribute, in which case `vnode.data.attrs` is undefined so `vnode.data.attrs.title` errors. This should fix that.