### PR TITLE
docs: fix option typo, position -> placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can pass **all** [Tippy.js](https://atomiks.github.io/tippyjs/) [options](ht
 ```vue
 <button 
   title="I'm on the left!" 
-  v-tippy="{position: 'left'}">
+  v-tippy="{placement: 'left'}">
   hover me
 </button>
 ```
@@ -47,7 +47,7 @@ You can tweak default settings globally while installing the plugin:
 
 ```js
 Vue.use(Tippy, {
-  position: 'left',
+  placement: 'left',
   onShown: () => console.log('lol'),
   // ... other options you wanna change globally
 })


### PR DESCRIPTION
It's `placement` in tippy.js 2.x

See: https://github.com/atomiks/tippyjs/blob/b4dd00896ed99198a1181b59964af99041a4b5fe/src/js/core/Tippy.js#L495